### PR TITLE
Update to latest version of manifest lib

### DIFF
--- a/opa-manager-operator/requirements.txt
+++ b/opa-manager-operator/requirements.txt
@@ -2,4 +2,4 @@ ops
 git+https://github.com/juju-solutions/resource-oci-image/@c5778285d332edf3d9a538f9d0c06154b7ec1b0b#egg=oci-image
 lightkube
 lightkube-models
-git+https://github.com/canonical/ops-lib-manifest.git@scp/subtractions
+git+https://github.com/canonical/ops-lib-manifest.git@main

--- a/opa-manager-operator/src/charm.py
+++ b/opa-manager-operator/src/charm.py
@@ -26,7 +26,7 @@ class OPAManagerCharm(CharmBase):
     def __init__(self, *args):
         super().__init__(*args)
 
-        self.manifests = ControllerManagerManifests(self.model.name, self.app.name, self.config)
+        self.manifests = ControllerManagerManifests(self, self.config)
         self.collector = Collector(self.manifests)
 
         self.client = Client(field_manager=self.app.name, namespace=self.model.name)

--- a/opa-manager-operator/src/manifests.py
+++ b/opa-manager-operator/src/manifests.py
@@ -38,7 +38,7 @@ class ModelNamespace(Patch):
             return
 
         log.info(f"Patching namespace for {obj.kind} {obj.metadata.name}")
-        obj.metadata.namespace = self.manifests.model_name
+        obj.metadata.namespace = self.manifests.model.name
 
 
 class WebhookConfiguration(Patch):
@@ -48,7 +48,7 @@ class WebhookConfiguration(Patch):
         if obj.kind == "ValidatingWebhookConfiguration" or obj.kind == "MutatingWebhookConfiguration":
             for webhook in obj.webhooks:
                 log.info(f"Patching clientConfig service namespace for {obj.kind} {obj.metadata.name}")
-                webhook.clientConfig.service.namespace = self.manifests.model_name
+                webhook.clientConfig.service.namespace = self.manifests.model.name
 
 class RoleBinding(Patch):
     """Update the namespace of any RoleBinding or ClusteRoleBinding subjects to the model name."""
@@ -57,7 +57,7 @@ class RoleBinding(Patch):
         if obj.kind == "RoleBinding" or obj.kind == "ClusterRoleBinding":
             for subject in obj.subjects:
                 log.info(f"Patching subject namespace for {obj.kind} {obj.metadata.name}")
-                subject.namespace = self.manifests.model_name
+                subject.namespace = self.manifests.model.name
 
 
 class ServicePorts(Patch):
@@ -74,7 +74,7 @@ class ServicePorts(Patch):
 
 
 class ControllerManagerManifests(Manifests):
-    def __init__(self, model_name, app_name, charm_config):
+    def __init__(self, charm, charm_config):
 
         manipulations = [
             SubtractEq(self, gatekeeper_system_ns),
@@ -86,7 +86,7 @@ class ControllerManagerManifests(Manifests):
             WebhookConfiguration(self),
             RoleBinding(self),
         ]
-        super().__init__("controller-manager", model_name, app_name, "upstream/controller-manager", manipulations)
+        super().__init__("controller-manager", charm.model, "upstream/controller-manager", manipulations)
         self.charm_config = charm_config
 
     @property


### PR DESCRIPTION
Update to the latest version of the manifest lib now that the changes from scp/subtractions were merged in. The API for manifests was changed slightly, and uses the harm model instead of passing in charm metadata (like the app name and model name) directly. 