### PR TITLE
Pin ops-lib-manifest

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -35,7 +35,7 @@ jobs:
       uses: charmed-kubernetes/actions-operator@main
       with:
           provider: microk8s
-          channel: 1.25
+          channel: 1.26/stable
     - name: Run test
       run: tox -e integration
     - name: Setup Debug Artifact Collection

--- a/opa-audit-operator/requirements.txt
+++ b/opa-audit-operator/requirements.txt
@@ -1,4 +1,4 @@
 ops
 lightkube
-lightkube-models
+lightkube-models<=1.24.1.4
 git+https://github.com/canonical/ops-lib-manifest.git@f411bf1b381d49f950de5a778ab7af7811fa646c

--- a/opa-audit-operator/requirements.txt
+++ b/opa-audit-operator/requirements.txt
@@ -1,4 +1,4 @@
 ops
 lightkube
 lightkube-models
-git+https://github.com/canonical/ops-lib-manifest.git@main
+git+https://github.com/canonical/ops-lib-manifest.git@f411bf1b381d49f950de5a778ab7af7811fa646c

--- a/opa-audit-operator/tests/integration/test_charm.py
+++ b/opa-audit-operator/tests/integration/test_charm.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import json
 import logging
+import shlex
 import time
 from pathlib import Path
 
@@ -13,7 +14,6 @@ from lightkube.generic_resource import (
     load_in_cluster_generic_resources,
 )
 from lightkube.resources.apiextensions_v1 import CustomResourceDefinition
-import shlex
 
 log = logging.getLogger(__name__)
 

--- a/opa-audit-operator/tests/integration/test_charm.py
+++ b/opa-audit-operator/tests/integration/test_charm.py
@@ -13,6 +13,7 @@ from lightkube.generic_resource import (
     load_in_cluster_generic_resources,
 )
 from lightkube.resources.apiextensions_v1 import CustomResourceDefinition
+import shlex
 
 log = logging.getLogger(__name__)
 
@@ -63,11 +64,13 @@ async def test_build_and_deploy(ops_test, charm):
     model = ops_test.model
     image = metadata["resources"]["gatekeeper-image"]["upstream-source"]
 
-    await model.deploy(
-        entity_url=charm.resolve(),
-        trust=True,
-        resources={"gatekeeper-image": image},
+    cmd = (
+        f"juju deploy -m {ops_test.model_full_name} "
+        f"{charm.resolve()} "
+        f"--resource gatekeeper-image={image} "
+        "--trust"
     )
+    await ops_test.run(*shlex.split(cmd), check=True)
     await model.block_until(
         lambda: "gatekeeper-audit" in model.applications, timeout=60
     )

--- a/opa-manager-operator/requirements.txt
+++ b/opa-manager-operator/requirements.txt
@@ -1,4 +1,4 @@
 ops
 lightkube
-lightkube-models
+lightkube-models<=1.24.1.4
 git+https://github.com/canonical/ops-lib-manifest.git@f411bf1b381d49f950de5a778ab7af7811fa646c

--- a/opa-manager-operator/requirements.txt
+++ b/opa-manager-operator/requirements.txt
@@ -1,4 +1,4 @@
 ops
 lightkube
 lightkube-models
-git+https://github.com/canonical/ops-lib-manifest.git@main
+git+https://github.com/canonical/ops-lib-manifest.git@f411bf1b381d49f950de5a778ab7af7811fa646c

--- a/opa-manager-operator/tests/integration/test_charm.py
+++ b/opa-manager-operator/tests/integration/test_charm.py
@@ -16,6 +16,7 @@ from lightkube.generic_resource import (
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.apiextensions_v1 import CustomResourceDefinition
 from lightkube.resources.core_v1 import Namespace
+import shlex
 
 log = logging.getLogger(__name__)
 
@@ -66,11 +67,13 @@ async def test_build_and_deploy(ops_test, charm):
     model = ops_test.model
     image = metadata["resources"]["gatekeeper-image"]["upstream-source"]
 
-    await model.deploy(
-        entity_url=charm.resolve(),
-        trust=True,
-        resources={"gatekeeper-image": image},
+    cmd = (
+        f"juju deploy -m {ops_test.model_full_name} "
+        f"{charm.resolve()} "
+        f"--resource gatekeeper-image={image} "
+        "--trust"
     )
+    await ops_test.run(*shlex.split(cmd), check=True)
     await model.block_until(
         lambda: "gatekeeper-controller-manager" in model.applications, timeout=60
     )

--- a/opa-manager-operator/tests/integration/test_charm.py
+++ b/opa-manager-operator/tests/integration/test_charm.py
@@ -2,6 +2,7 @@ import asyncio
 import contextlib
 import logging
 import random
+import shlex
 import time
 from pathlib import Path
 
@@ -16,7 +17,6 @@ from lightkube.generic_resource import (
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.apiextensions_v1 import CustomResourceDefinition
 from lightkube.resources.core_v1 import Namespace
-import shlex
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
Pins the version of ops lib manifest to the version used in the current 1.26/beta channels for the 2 charms.

It also pins lightkube models to 1.24.1.4 (the newest release was released december 2nd) to avoid the following error in the unit tests:
```
ImportError while loading conftest '/home/stone/ck/ck-repos/charmed-kubernetes/opa-gatekeeper-operators/opa-audit-operator/tests/unit/conftest.py'.
tests/unit/conftest.py:7: in <module>
    from charm import OPAAuditCharm
src/charm.py:21: in <module>
    from manifests import ControllerManagerManifests
src/manifests.py:59: in <module>
    pod_disruption_budget_beta = from_dict(
.tox/unit/lib/python3.10/site-packages/lightkube/codecs.py:59: in from_dict
    model = _load_model(d['apiVersion'], d['kind'])
.tox/unit/lib/python3.10/site-packages/lightkube/codecs.py:40: in _load_model
    raise LoadResourceError(f"{e}. If using a CRD, ensure you define a generic resource.")
E   lightkube.core.exceptions.LoadResourceError: No module named 'lightkube.resources.policy_v1beta1'. If using a CRD, ensure you define a generic resource.
```
Addtionally it switches the deploy step of the integration tests to deploy with a juju command instead of relying model.deploy which seems to be affected by [this bug](https://bugs.launchpad.net/juju/+bug/1992833)
