### PR TITLE
Build targeting only amd64 and arm64

### DIFF
--- a/opa-audit-operator/charmcraft.yaml
+++ b/opa-audit-operator/charmcraft.yaml
@@ -9,7 +9,6 @@ bases:
       channel: "22.04"
       architectures:
         - amd64
-        - arm
         - arm64
 parts:
   charm:

--- a/opa-manager-operator/charmcraft.yaml
+++ b/opa-manager-operator/charmcraft.yaml
@@ -9,7 +9,6 @@ bases:
       channel: "22.04"
       architectures:
         - amd64
-        - arm
         - arm64
 parts:
   charm:


### PR DESCRIPTION
charmstore rejects `arm` as an invalid charm architecture:

```
- review-error: manifest.bases.architectures: value is not a valid enumeration member; permitted: 'amd64', 'i386', 'armhf', 'arm64', 'ppc64el', 's390x', 'riscv64', 'all'                                                                      
```